### PR TITLE
Add Webpack to list of dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ yarn-error.log
 /.vscode
 composer.lock
 package-lock.json
+yarn.lock
+bun.lockb
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "lodash": "^4.17.21",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.63.6",
-        "sass-loader": "^13.3.2"
+        "sass-loader": "^13.3.2",
+        "webpack": "^5.90.3"
     },
     "dependencies": {
         "@alpinejs/intersect": "^3.13.3",


### PR DESCRIPTION
This PR adds webpack to the list of needed dependencies for build to make it easy for Ci/CD processes to have all packages needed for a successful build.

I've also added more lock files type to gitignore.